### PR TITLE
Fix to prevent being stuck without screen update until the first event comes

### DIFF
--- a/src/ui_sdl.c
+++ b/src/ui_sdl.c
@@ -774,7 +774,7 @@ char*ed_getprogbuf()
 void interactivemode(char*codetoload)
 {
   int codechanged=0;
-  uint32_t prevtimevalue=gettimevalue();
+  uint32_t prevtimevalue=gettimevalue() - 1;
   SDL_Event e;
 
   SDL_EnableKeyRepeat(SDL_DEFAULT_REPEAT_DELAY,10);


### PR DESCRIPTION
At the first time of the main event loop, the execution will be stuck at SDL_WaitEvent() without any calling updatescreen(). In my case of Native Client port, the first screen update happens at the time when the mouse pointer enters IBNIZ screen.
